### PR TITLE
Grow Wasm Pages In the core

### DIFF
--- a/lib/wasmboy.js
+++ b/lib/wasmboy.js
@@ -461,13 +461,13 @@ class WasmBoyLib {
         // Get our memory from our wasm instance
         const memory = instance.exports.memory;
 
+        // NOTE: Memory growing is now done in the wasm itself
         // Grow memory to wasmboy memory map
         // https://docs.google.com/spreadsheets/d/17xrEzJk5-sCB9J2mMJcVnzhbE-XH_NvczVSQH9OHvRk/edit?usp=sharing
-        // TODO: Scale Memory as needed with Cartridge size
-        if (memory.buffer.byteLength < this.wasmInstance.exports.wasmMemorySize) {
-          // Scale to the maximum needed pages
-          memory.grow(Math.ceil(this.wasmInstance.exports.wasmMemorySize / 1024 / 64));
-        }
+        // if (memory.buffer.byteLength < this.wasmInstance.exports.wasmMemorySize) {
+        //   // Scale to the maximum needed pages
+        //   memory.grow(Math.ceil(this.wasmInstance.exports.wasmMemorySize / 1024 / 64));
+        // }
 
         // Will stay in sync
         this.wasmByteMemory = new Uint8Array(this.wasmInstance.exports.memory.buffer);

--- a/wasm/constants/constants.ts
+++ b/wasm/constants/constants.ts
@@ -10,6 +10,7 @@
 
 // WasmBoy
 export const wasmMemorySize: u32 = 0x8B0000;
+export const wasmPages: u32 = wasmMemorySize / 1024 / 64;
 export const assemblyScriptMemoryBaseLocation: u32 = 0x000000;
 export const wasmBoyInternalStateLocation: u32 = 0x000400;
 export const wasmBoyInternalStateSize: u32 = 0x000400;

--- a/wasm/index.ts
+++ b/wasm/index.ts
@@ -29,7 +29,10 @@ import {
 } from './memory/index';
 import {
   performanceTimestamp
-} from './helpers/index'
+} from './helpers/index';
+import {
+  wasmPages
+} from './constants/constants';
 
 // Public Exports
 export {
@@ -86,6 +89,11 @@ export {
   drawBackgroundMapToWasmMemory,
   drawTileDataToWasmMemory
 } from './debug/debug';
+
+// Grow our memory to the specified size
+if(current_memory() < wasmPages) {
+  grow_memory(wasmPages - current_memory());
+}
 
 // Function to save state to memory for all of our classes
 export function saveState(): void {


### PR DESCRIPTION
Closes #50 

This will grow the number of pages in the core, using the memory map constants. Tested working fine with megaman2 and links awakening for GBC. :)