### PR TITLE
HDMA Fixes & Refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ import { WasmBoyDebugger, WasmBoySystemControls } from './debugger/index';
 // 	graphicsDisableScanlineRendering: true
 // });
 
+const gamePath = './games/donkeykongcountry.gbc';
+
 const wasmBoyOptions = {
 	isGbcEnabled: true,
 	isAudioEnabled: true,
@@ -64,7 +66,7 @@ export default class App extends Component {
 		WasmBoyController.addTouchInput('SELECT', selectElement, 'BUTTON');
 
 		//WasmBoy.loadGame('./test/testroms/blargg/cpu_instrs.gb')
-		WasmBoy.loadGame('./games/aevilia_discord.gbc')
+		WasmBoy.loadGame(gamePath)
 		.then(() => {
 			console.log('Wasmboy Ready!');
 		}).catch((error) => {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ import { WasmBoyDebugger, WasmBoySystemControls } from './debugger/index';
 // });
 
 const wasmBoyOptions = {
-	isGbcEnabled: false,
+	isGbcEnabled: true,
 	isAudioEnabled: true,
 	frameSkip: 1,
 	audioBatchProcessing: true,
@@ -21,7 +21,7 @@ const wasmBoyOptions = {
 	audioAccumulateSamples: true,
 	graphicsBatchProcessing: false,
 	graphicsDisableScanlineRendering: false,
-	tileRendering: true,
+	tileRendering: false,
 	tileCaching: true,
 	gameboySpeed: 1.0
 };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ import { WasmBoyDebugger, WasmBoySystemControls } from './debugger/index';
 // 	graphicsDisableScanlineRendering: true
 // });
 
-const gamePath = './games/donkeykongcountry.gbc';
+const gamePath = './games/aevilia_discord.gbc';
 
 const wasmBoyOptions = {
 	isGbcEnabled: true,
@@ -24,7 +24,7 @@ const wasmBoyOptions = {
 	graphicsBatchProcessing: false,
 	graphicsDisableScanlineRendering: false,
 	tileRendering: false,
-	tileCaching: true,
+	tileCaching: false,
 	gameboySpeed: 1.0
 };
 

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ export default class App extends Component {
 		WasmBoyController.addTouchInput('SELECT', selectElement, 'BUTTON');
 
 		//WasmBoy.loadGame('./test/testroms/blargg/cpu_instrs.gb')
-		WasmBoy.loadGame('./games/linksawakening.gb')
+		WasmBoy.loadGame('./games/aevilia_discord.gbc')
 		.then(() => {
 			console.log('Wasmboy Ready!');
 		}).catch((error) => {

--- a/lib/wasmboy.js
+++ b/lib/wasmboy.js
@@ -435,7 +435,7 @@ class WasmBoyLib {
               if (arg5 !== -9999) logString += ` 0x${arg5.toString(16)} `;
 
               // Uncomment to unthrottle
-              //console.log(logString);
+              // console.log(logString);
 
               // Comment the lines below to disable throttle
               this.logRequest = true;

--- a/wasm/memory/dma.ts
+++ b/wasm/memory/dma.ts
@@ -140,7 +140,14 @@ export function updateHblankHdma(): void {
 function hdmaTransfer(hdmaSource: u16, hdmaDestination: u16, transferLength: i32): void {
   for(let i: u16 = 0; i < <u16>transferLength; i++) {
     let sourceByte: u8 = eightBitLoadFromGBMemory(hdmaSource + i);
-    eightBitStoreIntoGBMemory(hdmaDestination + i, sourceByte);
+    // get the hdmaDestination with wrapping
+    // See issue #61: https://github.com/torch2424/wasmBoy/issues/61
+    let hdmaDestinationWithWrapping = hdmaDestination + i;
+    if (hdmaDestinationWithWrapping > 0x9FFF) {
+      hdmaDestinationWithWrapping = Memory.videoRamLocation + (hdmaDestinationWithWrapping - 0x9FFF - 1);
+      hexLog(hdmaSource, hdmaDestination, transferLength, hdmaDestination + i, hdmaDestinationWithWrapping)
+    }
+    eightBitStoreIntoGBMemory(hdmaDestinationWithWrapping, sourceByte);
   }
 
   // Set our Cycles used for the HDMA

--- a/wasm/memory/memory.ts
+++ b/wasm/memory/memory.ts
@@ -111,8 +111,7 @@ export class Memory {
   static DMACycles: i32 = 0;
   // Boolean we will mirror to indicate if Hdma is active
   static isHblankHdmaActive: boolean = false;
-  static hblankHdmaIndex: i32 = 0x00;
-  static hblankHdmaTotalBytes: i32 = 0x00;
+  static hblankHdmaTransferLengthRemaining: i32 = 0x00;
   // Store the source and destination for performance, and update as needed
   static hblankHdmaSource: u16 = 0x00;
   static hblankHdmaDestination: u16 = 0x00;


### PR DESCRIPTION
closes #61 
related to #49 

This fixes HDMA on HDMA intensive games like DKC, by simply correctly handling bit 7on 0xFF55 (HDMA trigger byte). However, we still have some maybe HDMA related bugs with Aevilia :(

# Screenshot

![screen shot 2018-04-17 at 12 25 04 am](https://user-images.githubusercontent.com/1448289/38858534-d255dd70-41e0-11e8-9e0a-714af4359c8f.png)
