### PR TITLE
Used the Page Visibility API to get Auto Saves on Mobile

### DIFF
--- a/lib/memory/autosave.js
+++ b/lib/memory/autosave.js
@@ -100,6 +100,14 @@ export const initializeAutoSave = wasmboyMemory => {
     },
     false
   );
+  // Mobile Page visibility, for pressing home, closing tabs, task switcher, etc...
+  // https://www.igvita.com/2015/11/20/dont-lose-user-and-app-state-use-page-visibility/
+  document.addEventListener('visibilitychange', () => {
+    // fires when user switches tabs, apps, goes to homescreen, etc.
+    if (document.visibilityState === 'hidden') {
+      _prepareAndStoreAutoSave(wasmboyMemory);
+    }
+  });
 
   // Restore any autosave lingering to be committed
   return _findAndCommitAutoSave(wasmboyMemory);


### PR DESCRIPTION
Tested on my device with the current debugger, autosaves now work on mobile! Meaning, no matter how you close your web browser, it should create an auto save state, and save the cartridge RAM (for games like Pokemon).

closes #91 