### PR TITLE
Fixed Cannot access fileName of undefined, when loading a ROM from a url

### DIFF
--- a/lib/wasmboy/rom.js
+++ b/lib/wasmboy/rom.js
@@ -41,7 +41,7 @@ export const fetchROMAsByteArray = (ROM, loadOptions) => {
       });
 
       let fileName = ROM;
-      if (loadOptions.fileName) {
+      if (loadOptions && loadOptions.fileName) {
         fileName = loadOptions.fileName;
       }
 


### PR DESCRIPTION
Found this when working on vaporboy 😢 