### PR TITLE
Fixed Wasm Global Implementation

### DIFF
--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -65,7 +65,7 @@ class WasmBoyAudioService {
       this.updateAudioCallback = updateAudioCallback;
 
       // Initialiuze our cached wasm constants
-      WASMBOY_SOUND_OUTPUT_LOCATION = this.wasmInstance.exports.soundOutputLocation;
+      WASMBOY_SOUND_OUTPUT_LOCATION = this.wasmInstance.exports.soundOutputLocation.valueOf();
 
       this.audioSources = [];
       this.averageTimeStretchFps = [];

--- a/lib/graphics/graphics.js
+++ b/lib/graphics/graphics.js
@@ -34,7 +34,7 @@ class WasmBoyGraphicsService {
     this.updateGraphicsCallback = updateGraphicsCallback;
 
     // Initialiuze our cached wasm constants
-    WASMBOY_CURRENT_FRAME_OUTPUT_LOCATION = this.wasmInstance.exports.frameInProgressVideoOutputLocation;
+    WASMBOY_CURRENT_FRAME_OUTPUT_LOCATION = this.wasmInstance.exports.frameInProgressVideoOutputLocation.valueOf();
 
     // Reset our frame queue and render promises
     this.frameQueue = [];

--- a/lib/memory/memory.js
+++ b/lib/memory/memory.js
@@ -58,14 +58,14 @@ class WasmBoyMemoryService {
 
   _initializeConstants() {
     // Initialiuze our cached wasm constants
-    this.WASMBOY_GAME_BYTES_LOCATION = this.wasmInstance.exports.gameBytesLocation;
-    this.WASMBOY_GAME_RAM_BANKS_LOCATION = this.wasmInstance.exports.gameRamBanksLocation;
-    this.WASMBOY_INTERNAL_STATE_SIZE = this.wasmInstance.exports.wasmBoyInternalStateSize;
-    this.WASMBOY_INTERNAL_STATE_LOCATION = this.wasmInstance.exports.wasmBoyInternalStateLocation;
-    this.WASMBOY_INTERNAL_MEMORY_SIZE = this.wasmInstance.exports.gameBoyInternalMemorySize;
-    this.WASMBOY_INTERNAL_MEMORY_LOCATION = this.wasmInstance.exports.gameBoyInternalMemoryLocation;
-    this.WASMBOY_PALETTE_MEMORY_SIZE = this.wasmInstance.exports.gameboyColorPaletteSize;
-    this.WASMBOY_PALETTE_MEMORY_LOCATION = this.wasmInstance.exports.gameboyColorPaletteLocation;
+    this.WASMBOY_GAME_BYTES_LOCATION = this.wasmInstance.exports.gameBytesLocation.valueOf();
+    this.WASMBOY_GAME_RAM_BANKS_LOCATION = this.wasmInstance.exports.gameRamBanksLocation.valueOf();
+    this.WASMBOY_INTERNAL_STATE_SIZE = this.wasmInstance.exports.wasmBoyInternalStateSize.valueOf();
+    this.WASMBOY_INTERNAL_STATE_LOCATION = this.wasmInstance.exports.wasmBoyInternalStateLocation.valueOf();
+    this.WASMBOY_INTERNAL_MEMORY_SIZE = this.wasmInstance.exports.gameBoyInternalMemorySize.valueOf();
+    this.WASMBOY_INTERNAL_MEMORY_LOCATION = this.wasmInstance.exports.gameBoyInternalMemoryLocation.valueOf();
+    this.WASMBOY_PALETTE_MEMORY_SIZE = this.wasmInstance.exports.gameboyColorPaletteSize.valueOf();
+    this.WASMBOY_PALETTE_MEMORY_LOCATION = this.wasmInstance.exports.gameboyColorPaletteLocation.valueOf();
   }
 
   getLoadedCartridgeMemoryState() {


### PR DESCRIPTION
Either caused by AS or New Chrome, but constant exported variables are now Wasm Globals. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global

Thus need to wrap these calls with a valueOf().

Fixes save states on Chrome 😄 