### PR TITLE
Fixed Load State (Too Fast Lock Up), as well as Options Callback

### DIFF
--- a/lib/wasmboy/wasmboy.js
+++ b/lib/wasmboy/wasmboy.js
@@ -261,6 +261,9 @@ class WasmBoyLibService {
     this.frameSkipCounter = 0;
 
     // Configurable Options
+    // Set callbacks to null and not undefined,
+    // For when configs are passed, we will be sure to
+    // add them as keys
     this.options = {
       headless: false,
       disablePauseOnHidden: false,
@@ -276,13 +279,13 @@ class WasmBoyLibService {
       audioAccumulateSamples: false,
       tileRendering: false,
       tileCaching: false,
-      updateGraphicsCallback: undefined,
-      updateAudioCallback: undefined,
-      saveStateCallback: undefined,
-      onReady: undefined,
-      onPlay: undefined,
-      onPause: undefined,
-      onLoadedAndStarted: undefined
+      updateGraphicsCallback: null,
+      updateAudioCallback: null,
+      saveStateCallback: null,
+      onReady: null,
+      onPlay: null,
+      onPause: null,
+      onLoadedAndStarted: null
     };
   }
 

--- a/lib/wasmboy/worker/update.js
+++ b/lib/wasmboy/worker/update.js
@@ -65,11 +65,15 @@ export function update(libWorker, passedIntervalRate) {
 
   // Set a timestamp for this moment
   // And make sure we are on track for FPS
-  currentHighResTime = addTimeStamp(libWorker);
   currentFps = libWorker.getFPS();
   if (currentFps > libWorker.options.gameboyFrameRate + 1) {
+    // Pop a timestamp off of the front
+    // This is to avoid infinite loop here on loadstate
+    libWorker.fpsTimeStamps.shift();
     scheduleNextUpdate(libWorker);
     return true;
+  } else {
+    currentHighResTime = addTimeStamp(libWorker);
   }
 
   // Check if we are outputting audio


### PR DESCRIPTION
This fixes some MAJOR bugs with version 0.2.0 that were introduced that my manual testing didn't catch 😢 

One was that on mobile, we would sometimes get ahead, which would then cause an infinite loop of FPS skip that could sometimes break itself out.

The other being me setting the initial callbacks to undefined, meaning they never get set because they aren't defined. null fixes this by being a false-y value, but still being in defined in our options object 😄 