### PR TITLE
Fixed Audio Autoplay

### DIFF
--- a/debugger/index.js
+++ b/debugger/index.js
@@ -105,6 +105,7 @@ export default class App extends Component {
       showDebugger: false,
       showOptions: false,
       showGamepad: false,
+      autoPlayROMOnLoad: false,
       notification: <div />
     };
   }
@@ -241,6 +242,21 @@ export default class App extends Component {
 
         <div style="text-align: center">
           <label class="checkbox">
+            Auto Play ROM on Load
+            <input
+              type="checkbox"
+              checked={this.state.autoPlayROMOnLoad}
+              onChange={() => {
+                const newState = Object.assign({}, this.state);
+                newState.autoPlayROMOnLoad = !newState.autoPlayROMOnLoad;
+                this.setState(newState);
+              }}
+            />
+          </label>
+        </div>
+
+        <div style="text-align: center">
+          <label class="checkbox">
             Show Touchpad
             <input
               type="checkbox"
@@ -265,6 +281,7 @@ export default class App extends Component {
           showNotification={text => {
             this.showNotification(text);
           }}
+          autoplay={this.state.autoPlayROMOnLoad}
         />
 
         <div>

--- a/debugger/wasmboyFilePicker/wasmboyFilePicker.js
+++ b/debugger/wasmboyFilePicker/wasmboyFilePicker.js
@@ -92,27 +92,38 @@ export class WasmBoyFilePicker extends Component {
 
   loadROM(file, fileName) {
     this.setFileLoadingStatus(true);
-    WasmBoy.loadROM(file)
-      .then(() => {
-        console.log('Wasmboy Ready!');
-        this.props.showNotification('Game Loaded! 🎉');
-        this.setFileLoadingStatus(false);
 
-        // Fire off Analytics
-        if (window !== undefined && window.gtag) {
-          gtag('event', 'load_rom_success');
-        }
-      })
-      .catch(error => {
-        console.log('Load Game Error:', error);
-        this.props.showNotification('Game Load Error! 😞');
-        this.setFileLoadingStatus(false);
+    // To test the new autoplay in safari
+    // and in chrome
+    WasmBoy.resumeAudioContext();
 
-        // Fire off Analytics
-        if (window !== undefined && window.gtag) {
-          gtag('event', 'load_rom_fail');
-        }
-      });
+    const loadROMTask = async () => {
+      await WasmBoy.loadROM(file);
+      this.props.showNotification('Game Loaded! 🎉');
+      this.setFileLoadingStatus(false);
+
+      // To test the new autoplay in safari
+      // and in chrome
+      if (this.props.autoplay) {
+        WasmBoy.play();
+      }
+
+      // Fire off Analytics
+      if (window !== undefined && window.gtag) {
+        gtag('event', 'load_rom_success');
+      }
+    };
+
+    loadROMTask().catch(error => {
+      console.log('Load Game Error:', error);
+      this.props.showNotification('Game Load Error! 😞');
+      this.setFileLoadingStatus(false);
+
+      // Fire off Analytics
+      if (window !== undefined && window.gtag) {
+        gtag('event', 'load_rom_fail');
+      }
+    });
 
     // Set our file name
     const newState = Object.assign({}, this.state);
@@ -123,10 +134,17 @@ export class WasmBoyFilePicker extends Component {
   // Allow passing a file
   // https://gist.github.com/AshikNesin/e44b1950f6a24cfcd85330ffc1713513
   loadLocalFile(event) {
+    // WasmBoy.resumeAudioContext();
+    // Handled by the onClick on the input
     this.loadROM(event.target.files[0], event.target.files[0].name);
+
+    if (this.props.autoplay) {
+      WasmBoy.play();
+    }
   }
 
   loadGoogleDriveFile(data) {
+    WasmBoy.resumeAudioContext();
     if (data.action === 'picked') {
       // Fetch from the drive api to download the file
       // https://developers.google.com/drive/v3/web/picker
@@ -158,6 +176,10 @@ export class WasmBoyFilePicker extends Component {
                 console.log('Wasmboy Ready!');
                 this.props.showNotification('Game Loaded! 🎉');
                 this.setFileLoadingStatus(false);
+
+                if (this.props.autoplay) {
+                  WasmBoy.play();
+                }
 
                 // Set our file name
                 const newState = Object.assign({}, this.state);
@@ -221,6 +243,9 @@ export class WasmBoyFilePicker extends Component {
                 name="resume"
                 onChange={event => {
                   this.loadLocalFile(event);
+                }}
+                onClick={() => {
+                  WasmBoy.resumeAudioContext();
                 }}
               />
               <span class="file-cta">

--- a/lib/audio/audio.js
+++ b/lib/audio/audio.js
@@ -49,9 +49,7 @@ class WasmBoyAudioService {
       }
       this.audioSources = [];
 
-      // Get our Audio context
-      // Not checking if we already have one because old one can become suspended and unusable on safari :(
-      this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+      this._createAudioContextIfNone();
 
       // Lastly get our audio constants
       return this.worker.postMessage({
@@ -66,6 +64,7 @@ class WasmBoyAudioService {
   // affected by any autoplay issues.
   // https://www.chromium.org/audio-video/autoplay
   resumeAudioContext() {
+    this._createAudioContextIfNone();
     if (this.audioContext.state === 'suspended') {
       this.audioContext.resume();
       this.audioPlaytime = this.audioContext.currentTime;
@@ -239,6 +238,13 @@ class WasmBoyAudioService {
 
     // Reset our audioPlaytime
     this.audioPlaytime = this.audioContext.currentTime + DEFAULT_AUDIO_LATENCY_IN_SECONDS;
+  }
+
+  _createAudioContextIfNone() {
+    if (!this.audioContext) {
+      // Get our Audio context
+      this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    }
   }
 }
 


### PR DESCRIPTION
Noticed some errors with `resumeAudioContext` in safari, found out `resumeAudioContext` is the issue. Updated docs that this function call should just be bound to a common element.

<img width="1280" alt="screen shot 2018-10-28 at 7 27 48 pm" src="https://user-images.githubusercontent.com/1448289/47626334-cc9de300-dae7-11e8-978f-ccb964d82337.png">
