### PR TITLE
Removed the debugger deploy option

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "debugger:serve": "npx run-s debugger:build debugger:serve:nobuild",
     "debugger:serve:nobuild": "preact serve",
     "debugger:build": "preact build -p --src demo/debugger --no-prerender --service-worker false",
-    "debugger:deploy": "npx run-s debugger:build",
     "benchmark:build": "npx rollup -c --environment PROD,BENCHMARK",
     "benchmark:watch": "npx rollup -c -w --environment BENCHMARK",
     "demo:cname": "echo 'wasmboy.app' > build/CNAME",


### PR DESCRIPTION
Since we now have multiple demos, we should be deploying them with the same lib version, and the way [gh-pages](https://www.npmjs.com/package/gh-pages) works, would be great to build all of them / update at once.

Forgot to remove this, and it is why the debugger was a version behind.