### PR TITLE
Fixed Benchmark Styles for Mobile

### DIFF
--- a/demo/benchmark/benchmarkChart.js
+++ b/demo/benchmark/benchmarkChart.js
@@ -21,6 +21,7 @@ export const getChartConfig = (title, xAxisTitle, yAxisTitle, isHigherBetter, th
     plugins: [ChartJsPluginDownsample],
     options: {
       responsive: true,
+      maintainAspectRatio: false,
       title: {
         display: true,
         text: title

--- a/demo/benchmark/benchmarkResults.js
+++ b/demo/benchmark/benchmarkResults.js
@@ -278,13 +278,17 @@ export default class BenchmarkRunner extends Component {
 
         <div>
           <h1>General Statistics of Times (In Microseconds)</h1>
-          {generalStatsTable}
+          <div class="wasmboy-benchmark__stats-table">{generalStatsTable}</div>
         </div>
 
         <div>
           <h1>Frame Times Visualization</h1>
-          <canvas id="times-vs-frames-chart" />
-          <canvas id="fps-vs-frames-chart" />
+          <div class="wasmboy-benchmark__chart-container">
+            <canvas id="times-vs-frames-chart" />
+          </div>
+          <div class="wasmboy-benchmark__chart-container">
+            <canvas id="fps-vs-frames-chart" />
+          </div>
         </div>
       </section>
     );

--- a/demo/benchmark/index.css
+++ b/demo/benchmark/index.css
@@ -93,8 +93,20 @@ html {
   margin-bottom: 10px;
 }
 
+.wasmboy-benchmark__stats-table {
+  width: 100%;
+  overflow: auto;
+}
+
 .results table {
   margin-top: 10px;
   min-height: 100px;
   margin-bottom: 10px;
+}
+
+.wasmboy-benchmark__chart-container {
+  position: relative;
+  width: 100%;
+  height: 50vh;
+  max-height: 800px;
 }


### PR DESCRIPTION
Something I noticed while collecting data for the benchmarking app 😄 

Fixing before releasing.

![mobilebenchmarkstyles](https://user-images.githubusercontent.com/1448289/49433983-0ce82500-f768-11e8-9f06-63bf36f4ce5e.gif)
