### PR TITLE
Fixed Memory Leak on Page Refresh

### DIFF
--- a/lib/debug/debug.js
+++ b/lib/debug/debug.js
@@ -1,8 +1,7 @@
 import { WasmBoyLib } from '../wasmboy/wasmboy';
-import { waitForLibWorkerMessageType } from '../wasmboy/onmessage';
-import { WasmBoyAudio } from '../audio/audio';
 import { WasmBoyGraphics } from '../graphics/graphics';
 
+import { waitForLibWorkerMessageType } from '../wasmboy/onmessage';
 import { WORKER_MESSAGE_TYPE } from '../worker/constants';
 import { getEventData } from '../worker/util';
 

--- a/lib/wasmboy/render.js
+++ b/lib/wasmboy/render.js
@@ -7,7 +7,6 @@ import raf from 'raf';
 
 // WasmBoy Modules
 import { WasmBoyGraphics } from '../graphics/graphics';
-import { WasmBoyAudio } from '../audio/audio';
 import { WasmBoyController } from '../controller/controller';
 
 // Function to render our emulator output

--- a/lib/wasmboy/wasmboy.js
+++ b/lib/wasmboy/wasmboy.js
@@ -14,6 +14,8 @@ import { libWorkerOnMessage } from './onmessage';
 // requestAnimationFrame() for headless mode
 import raf from 'raf';
 
+let isWindowUnloading = false;
+
 // Our Main Orchestrator of the WasmBoy lib
 class WasmBoyLibService {
   // Start the request to our wasm module
@@ -35,22 +37,32 @@ class WasmBoyLibService {
     this._resetConfig();
 
     // Add some listeners for when we are put into the background
-    // TODO(torch2424): re-enable pausing on hidding.
-    // For some reason this causes a HUGE memory leak
-    // Memory leak, that persists between page refresh.
-    /*
-      if (typeof window !== 'undefined') {
-        window.document.addEventListener('visibilitychange', () => {
-          // fires when user switches tabs, apps, goes to homescreen, etc.
-          if (document.visibilityState === 'hidden') {
-            if (this.options && this.options.disablePauseOnHidden) {
-              return;
-            }
-            this.pause();
+    if (typeof window !== 'undefined') {
+      // Calling promises in the hidden visibility change
+      // On page reload, leaks memory
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=932885&can=1&q=torchh2424%40gmail.com&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified
+      // Thus we need this hack, to get around this
+      window.addEventListener('beforeunload', function(event) {
+        isWindowUnloading = true;
+      });
+
+      window.document.addEventListener('visibilitychange', () => {
+        // fires when user switches tabs, apps, goes to homescreen, etc.
+        if (document.visibilityState === 'hidden') {
+          if (this.options && this.options.disablePauseOnHidden) {
+            return;
           }
-        });
-      }
-    */
+
+          setTimeout(() => {
+            if (!isWindowUnloading) {
+              // See the comment above about the memory leak
+              // This fires off a bunch of promises, thus a leak
+              this.pause();
+            }
+          }, 0);
+        }
+      });
+    }
   }
 
   // Function to initialize/configure Wasmboy

--- a/lib/wasmboy/wasmboy.js
+++ b/lib/wasmboy/wasmboy.js
@@ -35,17 +35,22 @@ class WasmBoyLibService {
     this._resetConfig();
 
     // Add some listeners for when we are put into the background
-    if (typeof window !== 'undefined') {
-      window.document.addEventListener('visibilitychange', () => {
-        // fires when user switches tabs, apps, goes to homescreen, etc.
-        if (document.visibilityState === 'hidden') {
-          if (this.options && this.options.disablePauseOnHidden) {
-            return;
+    // TODO(torch2424): re-enable pausing on hidding.
+    // For some reason this causes a HUGE memory leak
+    // Memory leak, that persists between page refresh.
+    /*
+      if (typeof window !== 'undefined') {
+        window.document.addEventListener('visibilitychange', () => {
+          // fires when user switches tabs, apps, goes to homescreen, etc.
+          if (document.visibilityState === 'hidden') {
+            if (this.options && this.options.disablePauseOnHidden) {
+              return;
+            }
+            this.pause();
           }
-          this.pause();
-        }
-      });
-    }
+        });
+      }
+    */
   }
 
   // Function to initialize/configure Wasmboy


### PR DESCRIPTION
Opened a bug on chrome at: https://bugs.chromium.org/p/chromium/issues/detail?id=932885&can=1&q=torchh2424%40gmail.com&colspec=ID%20Pri%20M%20Stars%20ReleaseBlock%20Component%20Status%20Owner%20Summary%20OS%20Modified

This is caused by launching promises on the `'visibilitychange'` event. See the bug above for an isolated demo.

And here's a blurb anyone googling will hopefully pick up:

If you record heap snapshots , allocation instrumentation on timeline , or allocation sampling in the chrome dev tools , you will see Detached Window and or Promise in the memory view. This bug has those behaviors and hopefully I diagnosed the bug correctly (this time), and will be fixed in future Chrome 😄 

# Current master

![memoryleakmaster](https://user-images.githubusercontent.com/1448289/52906807-192d3b80-3209-11e9-9126-3e80e8e9002b.gif)

# Fixed Master

**Memory no longer leaks**

![memoryleakfixed](https://user-images.githubusercontent.com/1448289/52906798-031f7b00-3209-11e9-9e02-9f45e14a5fc7.gif)

**Pausing on hidden still works**

![memoryleakfixaudio](https://user-images.githubusercontent.com/1448289/52906806-13cff100-3209-11e9-8bb5-3bf8a5b19c74.gif)

