### PR TITLE
Added core and lib directory to published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,8 @@
   },
   "files": [
     "dist",
+    "core",
+    "lib",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Adds the core and lib directory to the published package. This will be helpful for AssemblyScript projects to only use the core (Assemblyscript), or JS projects that want to use the source directly, instead of our pre-compiled output in dist (Maybe some specific compiler stuff on their end?). :smile: 